### PR TITLE
Add form item demo

### DIFF
--- a/lib/salad_storybook_web/live/demo/dashboard_three_live.ex
+++ b/lib/salad_storybook_web/live/demo/dashboard_three_live.ex
@@ -110,7 +110,7 @@ defmodule SaladStorybookWeb.Demo.DashboardThree do
     </header>
     <main class="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
       <div class="grid gap-4 md:grid-cols-2 md:gap-8 lg:grid-cols-4">
-        <.card x-chunk="dashboard-01-chunk-0">
+        <.card>
           <.card_header class="flex flex-row items-center justify-between space-y-0 pb-2">
             <.card_title class="text-sm font-medium">
               Total Revenue
@@ -124,7 +124,7 @@ defmodule SaladStorybookWeb.Demo.DashboardThree do
             </p>
           </.card_content>
         </.card>
-        <.card x-chunk="dashboard-01-chunk-1">
+        <.card>
           <.card_header class="flex flex-row items-center justify-between space-y-0 pb-2">
             <.card_title class="text-sm font-medium">
               Subscriptions
@@ -138,7 +138,7 @@ defmodule SaladStorybookWeb.Demo.DashboardThree do
             </p>
           </.card_content>
         </.card>
-        <.card x-chunk="dashboard-01-chunk-2">
+        <.card>
           <.card_header class="flex flex-row items-center justify-between space-y-0 pb-2">
             <.card_title class="text-sm font-medium">Sales</.card_title>
             <.icon name="hero-credit-card" class="h-4 w-4 text-muted-foreground" />
@@ -150,7 +150,7 @@ defmodule SaladStorybookWeb.Demo.DashboardThree do
             </p>
           </.card_content>
         </.card>
-        <.card x-chunk="dashboard-01-chunk-3">
+        <.card>
           <.card_header class="flex flex-row items-center justify-between space-y-0 pb-2">
             <.card_title class="text-sm font-medium">Active Now</.card_title>
             <.icon name="hero-cursor-arrow-rays" class="h-4 w-4 text-muted-foreground" />
@@ -164,7 +164,7 @@ defmodule SaladStorybookWeb.Demo.DashboardThree do
         </.card>
       </div>
       <div class="grid gap-4 md:gap-8 lg:grid-cols-2 xl:grid-cols-5">
-        <.card class="xl:col-span-3" x-chunk="dashboard-01-chunk-4">
+        <.card class="xl:col-span-3">
           <.card_header class="flex flex-row items-center">
             <div class="grid gap-2">
               <.card_title>Transactions</.card_title>
@@ -300,7 +300,7 @@ defmodule SaladStorybookWeb.Demo.DashboardThree do
             </.table>
           </.card_content>
         </.card>
-        <.card class="xl:col-span-2" x-chunk="dashboard-01-chunk-5">
+        <.card class="xl:col-span-2">
           <.card_header>
             <.card_title>Recent Sales</.card_title>
           </.card_header>

--- a/lib/salad_storybook_web/live/demo/dashboard_two_live.ex
+++ b/lib/salad_storybook_web/live/demo/dashboard_two_live.ex
@@ -258,7 +258,7 @@ defmodule SaladStorybookWeb.Demo.DashboardTwo do
         <main class="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-0 md:gap-8 lg:grid-cols-3 xl:grid-cols-3">
           <div class="grid auto-rows-max items-start gap-4 md:gap-8 lg:col-span-2">
             <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
-              <.card class="sm:col-span-2" x-chunk="dashboard-05-chunk-0">
+              <.card class="sm:col-span-2">
                 <.card_header class="pb-3">
                   <.card_title>
                     Your Orders
@@ -274,7 +274,7 @@ defmodule SaladStorybookWeb.Demo.DashboardTwo do
                   </.button>
                 </.card_footer>
               </.card>
-              <.card x-chunk="dashboard-05-chunk-1">
+              <.card>
                 <.card_header class="pb-2">
                   <.card_description>
                     This Week
@@ -592,7 +592,7 @@ defmodule SaladStorybookWeb.Demo.DashboardTwo do
             </.tabs>
           </div>
           <div>
-            <.card class="overflow-hidden" x-chunk="dashboard-05-chunk-4">
+            <.card class="overflow-hidden">
               <.card_header class="flex flex-row items-start bg-muted/50">
                 <div class="grid gap-0.5">
                   <.card_title class="group flex items-center gap-2 text-lg">

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule SaladStorybook.MixProject do
 
       # load local salad_ui on dev from local path
       (Mix.env() == :prod &&
-         {:salad_ui, github: "bluzky/salad_ui", tag: "v0.7.0"}) ||
+         {:salad_ui, github: "bluzky/salad_ui", tag: "v0.8.0"}) ||
         {:salad_ui, path: "../salad_ui"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule SaladStorybook.MixProject do
 
       # load local salad_ui on dev from local path
       (Mix.env() == :prod &&
-         {:salad_ui, github: "bluzky/salad_ui", tag: "v0.6.0"}) ||
+         {:salad_ui, github: "bluzky/salad_ui", tag: "v0.7.0"}) ||
         {:salad_ui, path: "../salad_ui"}
     ]
   end

--- a/storybook/examples/form_demo.story.exs
+++ b/storybook/examples/form_demo.story.exs
@@ -8,12 +8,17 @@ defmodule Storybook.Examples.FormDemo.Item do
     field :name, :string
     field :description, :string
     field :material, :string
-    field :sellable, :boolean, default: false
+    field :sellable, :boolean, default: true
+    field :virtual, :boolean, default: false
+    field :color, :string, default: "red"
+    field :scale, :integer, default: 10
+    field :toggle, :boolean
+    field :style, :string
   end
 
   def changeset(user, params \\ %{}) do
     user
-    |> cast(params, [:name, :description, :material, :sellable])
+    |> cast(params, [:name, :description, :material, :sellable, :color, :scale, :virtual])
     |> validate_required([:name, :description])
   end
 end
@@ -22,7 +27,7 @@ defmodule Storybook.Examples.FormDemo do
   @moduledoc false
   use PhoenixStorybook.Story, :example
 
-  import SaladUI.Badge
+  import SaladStorybookWeb.CoreComponents, only: [icon: 1]
   import SaladUI.Button
   import SaladUI.Checkbox
   import SaladUI.Form
@@ -30,8 +35,11 @@ defmodule Storybook.Examples.FormDemo do
   import SaladUI.Label
   import SaladUI.RadioGroup
   import SaladUI.Select
+  import SaladUI.Slider
+  import SaladUI.Switch
   import SaladUI.Textarea
-  import SaladUI.Tooltip
+  import SaladUI.Toggle
+  import SaladUI.ToggleGroup
 
   alias Storybook.Examples.FormDemo.Item
 
@@ -115,6 +123,74 @@ defmodule Storybook.Examples.FormDemo do
                   <.checkbox id="sellable" field={f[:sellable]} />
                   <.label for="sellable">sellable</.label>
                 </div>
+                <div class="flex items-center space-x-2">
+                  <.switch id="virtual" field={f[:virtual]} />
+                  <.label for="virtual">Is virtual?</.label>
+                </div>
+              </.form_item>
+
+              <.form_item>
+                <.label>Color</.label>
+                <.select
+                  :let={select}
+                  field={f[:color]}
+                  id="color-select"
+                  name="color"
+                  placeholder="Select a color"
+                >
+                  <.select_trigger builder={select} class="w-[180px]" />
+                  <.select_content class="w-full" builder={select}>
+                    <.select_group>
+                      <.select_item builder={select} value="red" label="Red"></.select_item>
+                      <.select_item builder={select} value="green" label="Blue"></.select_item>
+                      <.select_item builder={select} value="pink"></.select_item>
+                      <.select_separator />
+                      <.select_item builder={select} disabled value="yellow" label="YELLOW">
+                      </.select_item>
+                      <.select_item builder={select} value="purple"></.select_item>
+                    </.select_group>
+                  </.select_content>
+                </.select>
+              </.form_item>
+              <.form_item>
+                <.label>Scale</.label>
+                <div>
+                  <.slider
+                    class="w-[60%] inline-block"
+                    id="slider-single-step-slider"
+                    max={50}
+                    step={5}
+                    field={f[:scale]}
+                    onchange="document.querySelector('#slider-value').value = this.value"
+                  />
+                  <.input class="inline w-16" type="number" id="slider-value" />
+                </div>
+              </.form_item>
+
+              <.form_item>
+                <.label>Toggle</.label>
+                <div>
+                  <.toggle field={f[:toggle]} size="sm" variant="outline">Toggle me</.toggle>
+                </div>
+              </.form_item>
+
+              <.form_item>
+                <.label>Style</.label>
+                <.toggle_group :let={builder} field={f[:style]} class="justify-start">
+                  <.toggle_group_item value="bold" builder={builder} aria-label="Toggle bold">
+                    <.icon name="hero-bold" class="h-4 w-4" />
+                  </.toggle_group_item>
+                  <.toggle_group_item value="italic" builder={builder} aria-label="Toggle italic">
+                    <.icon name="hero-italic" class="h-4 w-4" />
+                  </.toggle_group_item>
+                  <.toggle_group_item
+                    value="underline"
+                    builder={builder}
+                    aria-label="Toggle underline"
+                  >
+                    <.icon name="hero-underline" class="h-4 w-4" />
+                  </.toggle_group_item>
+                </.toggle_group>
               </.form_item>
 
               <.button type="submit">Submit</.button>

--- a/storybook/examples/form_demo.story.exs
+++ b/storybook/examples/form_demo.story.exs
@@ -1,0 +1,94 @@
+defmodule Storybook.Examples.FormDemo.Item do
+  @moduledoc false
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "items" do
+    field :name, :string
+    field :description, :string
+    field :material, :string
+  end
+
+  def changeset(user, params \\ %{}) do
+    user
+    |> cast(params, [:name, :description, :material])
+    |> validate_required([:name])
+  end
+end
+
+defmodule Storybook.Examples.FormDemo do
+  @moduledoc false
+  use PhoenixStorybook.Story, :example
+
+  import SaladUI.Badge
+  import SaladUI.Button
+  import SaladUI.Form
+  import SaladUI.Input
+  import SaladUI.Label
+  import SaladUI.Select
+  import SaladUI.Textarea
+  import SaladUI.Tooltip
+
+  alias Storybook.Examples.FormDemo.Item
+
+  def doc do
+    "An example of convert React template for Shadcn ui to heex template using SaladUI."
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    form =
+      %Item{}
+      |> Item.changeset()
+      |> to_form()
+
+    {:ok, assign(socket, :form, form)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="grid h-screen w-full">
+      <div class="flex flex-col">
+        <main class="grid flex-1 gap-4 overflow-auto p-4 grid-cols-1 md:grid-cols-2">
+          <div class="relative hidden flex-col items-start gap-8 md:flex">
+            <.form :let={f} for={@form} phx-submit="create_item" class="grid w-full items-start gap-6">
+              <.form_item>
+                <.form_label error={not Enum.empty?(f[:name].errors)}>Item name</.form_label>
+                <.input
+                  field={f[:name]}
+                  type="text"
+                  class={error_class(f[:name])}
+                  placeholder="saladui"
+                />
+                <.form_description>
+                  This is your public display name.
+                </.form_description>
+                <.form_message field={f[:name]} />
+              </.form_item>
+              <.button type="submit">Submit</.button>
+            </.form>
+          </div>
+        </main>
+      </div>
+    </div>
+    """
+  end
+
+  defp error_class(field) do
+    if Enum.empty?(field.errors), do: "", else: "border-destructive text-destructive"
+  end
+
+  @impl true
+  def handle_event("create_item", params, socket) do
+    case %Item{} |> Item.changeset(params) |> Ecto.Changeset.apply_action(:insert) do
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+
+      {:ok, _changeset} ->
+        # save changeset
+        {:noreply, assign(socket, :message, "Create item successfully")}
+    end
+  end
+end

--- a/storybook/salad_ui_component/select.story.exs
+++ b/storybook/salad_ui_component/select.story.exs
@@ -37,16 +37,16 @@ defmodule Storybook.SaladUIComponents.Select do
         let: :select,
         slots: [
           """
-            <.select_trigger instance={select} class="w-[180px]"/>
-            <.select_content class="w-full" instance={select}>
+            <.select_trigger builder={select} class="w-[180px]"/>
+            <.select_content class="w-full" builder={select}>
               <.select_group>
                 <.select_label>Fruits</.select_label>
-                <.select_item instance={select} value="apple" label="Apple"></.select_item>
-                <.select_item instance={select} value="banana" label="Banana"></.select_item>
-                <.select_item instance={select}  value="blueberry"></.select_item>
+                <.select_item builder={select} value="apple" label="Apple"></.select_item>
+                <.select_item builder={select} value="banana" label="Banana"></.select_item>
+                <.select_item builder={select}  value="blueberry"></.select_item>
                 <.select_separator />
-                <.select_item instance={select} disabled value="grapes"></.select_item>
-                <.select_item instance={select} value="pineapple"></.select_item>
+                <.select_item builder={select} disabled value="grapes"></.select_item>
+                <.select_item builder={select} value="pineapple"></.select_item>
               </.select_group>
             </.select_content>
           """

--- a/storybook/salad_ui_component/tab.story.exs
+++ b/storybook/salad_ui_component/tab.story.exs
@@ -25,61 +25,63 @@ defmodule Storybook.SaladUIComponents.Tab do
       %Variation{
         id: :tab,
         description: "tab trigger target must be the same with target tab_content's id",
-        template: """
-        <.tabs default="account" id="settings" class="w-[400px]">
-          <.tabs_list class="grid w-full grid-cols-2">
-            <.tabs_trigger root="settings" value="account">account</.tabs_trigger>
-            <.tabs_trigger root="settings" value="password">password</.tabs_trigger>
-          </.tabs_list>
-          <.tabs_content value="account">
-            <.card>
-              <.card_header>
-                <.card_title>Account</.card_title>
-                <.card_description>
-                  Make changes to your account here. Click save when you're done.
-                </.card_description>
-              </.card_header>
-              <.card_content class="space-y-2">
-                <div class="space-y-1">
-                  <.label html-for="name">Name</.label>
-                  <.input id="name" default-value="Pedro Duarte" />
-                </div>
-                <div class="space-y-1">
-                  <.label html-for="username">Username</.label>
-                  <.input id="username" default-value="@peduarte" />
-                </div>
-              </.card_content>
-              <.card_footer>
-                <.button>Save changes</.button>
-              </.card_footer>
-            </.card>
-          </.tabs_content>
-          <.tabs_content value="password">
-            <.card>
-              <.card_header>
-                <.card_title>Password</.card_title>
-                <.card_description>
-                  Change your password here. After saving, you'll be logged out.
-                </.card_description>
-              </.card_header>
-              <.card_content class="space-y-2">
-                <div class="space-y-1">
-                  <.label html-for="current">Current password</.label>
-                  <.input id="current" type="password" />
-                </div>
-                <div class="space-y-1">
-                  <.label html-for="new">New password</.label>
-                  <.input id="new" type="password" />
-                </div>
-              </.card_content>
-              <.card_footer>
-                <.button>Save password</.button>
-              </.card_footer>
-            </.card>
-          </.tabs_content>
-        </.tabs>
-        """,
-        attributes: %{}
+        let: :builder,
+        attributes: %{default: "account", id: "settings", class: "w-[400px]"},
+        slots: [
+          """
+                    <.tabs_list class="grid w-full grid-cols-2">
+              <.tabs_trigger builder={builder} value="account">account</.tabs_trigger>
+              <.tabs_trigger builder={builder} value="password">password</.tabs_trigger>
+            </.tabs_list>
+            <.tabs_content value="account">
+              <.card>
+                <.card_header>
+                  <.card_title>Account</.card_title>
+                  <.card_description>
+                    Make changes to your account here. Click save when you're done.
+                  </.card_description>
+                </.card_header>
+                <.card_content class="space-y-2">
+                  <div class="space-y-1">
+                    <.label html-for="name">Name</.label>
+                    <.input id="name" default-value="Pedro Duarte" />
+                  </div>
+                  <div class="space-y-1">
+                    <.label html-for="username">Username</.label>
+                    <.input id="username" default-value="@peduarte" />
+                  </div>
+                </.card_content>
+                <.card_footer>
+                  <.button>Save changes</.button>
+                </.card_footer>
+              </.card>
+            </.tabs_content>
+            <.tabs_content value="password">
+              <.card>
+                <.card_header>
+                  <.card_title>Password</.card_title>
+                  <.card_description>
+                    Change your password here. After saving, you'll be logged out.
+                  </.card_description>
+                </.card_header>
+                <.card_content class="space-y-2">
+                  <div class="space-y-1">
+                    <.label html-for="current">Current password</.label>
+                    <.input id="current" type="password" />
+                  </div>
+                  <div class="space-y-1">
+                    <.label html-for="new">New password</.label>
+                    <.input id="new" type="password" />
+                  </div>
+                </.card_content>
+                <.card_footer>
+                  <.button>Save password</.button>
+                </.card_footer>
+              </.card>
+            </.tabs_content>
+
+          """
+        ]
       }
     ]
   end

--- a/storybook/salad_ui_component/toggle.story.exs
+++ b/storybook/salad_ui_component/toggle.story.exs
@@ -14,7 +14,7 @@ defmodule Storybook.SaladUIComponents.Toggle do
       %Variation{
         id: :toggle_pressed,
         attributes: %{
-          pressed: true
+          value: true
         },
         slots: ["B"]
       },

--- a/storybook/salad_ui_component/toggle_group.story.exs
+++ b/storybook/salad_ui_component/toggle_group.story.exs
@@ -29,7 +29,7 @@ defmodule Storybook.SaladUIComponents.ToggleGroup do
       %Variation{
         id: :toggle_group_multiple,
         let: :builder,
-        attributes: %{name: "multiple_group", type: "multiple", value: ["bold"]},
+        attributes: %{name: "multiple_group", multiple: true, value: ["bold"]},
         slots: [
           """
           <.toggle_group_item value="bold" builder={builder} aria-label="Toggle bold">
@@ -48,7 +48,7 @@ defmodule Storybook.SaladUIComponents.ToggleGroup do
       %Variation{
         id: :toggle_group_outline,
         let: :builder,
-        attributes: %{name: "multiple_group_outline", type: "multiple", value: ["bold"], variant: "outline", size: "sm"},
+        attributes: %{name: "multiple_group_outline", multiple: true, value: ["bold"], variant: "outline", size: "sm"},
         slots: [
           """
           <.toggle_group_item value="bold" builder={builder} aria-label="Toggle bold">


### PR DESCRIPTION
## Summary by Sourcery

Add a new form demo example to the Storybook, demonstrating the use of various Salad UI components in a form. Refactor existing Storybook components to improve attribute naming consistency and remove unnecessary attributes from dashboard components. Update the Salad UI library to a newer version.

New Features:
- Introduce a new form demo example in the Storybook, showcasing a form with various input components like text input, textarea, radio group, checkbox, switch, select, slider, toggle, and toggle group.

Enhancements:
- Refactor the tab and select components in the Storybook to use a 'builder' attribute instead of 'instance', improving consistency and clarity in the component API.
- Update the toggle group component to use 'multiple' attribute instead of 'type' for specifying multiple selection, enhancing readability and alignment with common attribute naming conventions.

Build:
- Update the Salad UI dependency version from v0.6.0 to v0.8.0 in the mix.exs file, ensuring the project uses the latest features and fixes from the library.

Chores:
- Remove 'x-chunk' attributes from card components in the DashboardTwo and DashboardThree modules, simplifying the component structure.