### PR TITLE
Fix dashboard

### DIFF
--- a/lib/salad_storybook_web/live/demo/dashboard_one_live.ex
+++ b/lib/salad_storybook_web/live/demo/dashboard_one_live.ex
@@ -211,13 +211,13 @@ defmodule SaladStorybookWeb.Demo.DashboardOne do
           </.dropdown_menu>
         </header>
         <main class="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-0 md:gap-8">
-          <.tabs default="all" id="tabs">
+          <.tabs :let={builder} default="all" id="tabs">
             <div class="flex items-center">
               <.tabs_list>
-                <.tabs_trigger value="all" root="tabs">All</.tabs_trigger>
-                <.tabs_trigger value="active" root="tabs">Active</.tabs_trigger>
-                <.tabs_trigger value="draft" root="tabs">Draft</.tabs_trigger>
-                <.tabs_trigger value="archived" root="tabs" class="hidden sm:flex">
+                <.tabs_trigger value="all" builder={builder}>All</.tabs_trigger>
+                <.tabs_trigger value="active" builder={builder}>Active</.tabs_trigger>
+                <.tabs_trigger value="draft" builder={builder}>Draft</.tabs_trigger>
+                <.tabs_trigger value="archived" builder={builder} class="hidden sm:flex">
                   Archived
                 </.tabs_trigger>
               </.tabs_list>

--- a/lib/salad_storybook_web/live/demo/dashboard_two_live.ex
+++ b/lib/salad_storybook_web/live/demo/dashboard_two_live.ex
@@ -311,16 +311,16 @@ defmodule SaladStorybookWeb.Demo.DashboardTwo do
                 </.card_footer>
               </.card>
             </div>
-            <.tabs id="tabs" default="week">
+            <.tabs :let={builder} id="tabs" default="week">
               <div class="flex items-center">
                 <.tabs_list>
-                  <.tabs_trigger root="tabs" value="week">
+                  <.tabs_trigger builder={builder} value="week">
                     Week
                   </.tabs_trigger>
-                  <.tabs_trigger root="tabs" value="month">
+                  <.tabs_trigger builder={builder} value="month">
                     Month
                   </.tabs_trigger>
-                  <.tabs_trigger root="tabs" value="year">
+                  <.tabs_trigger builder={builder} value="year">
                     Year
                   </.tabs_trigger>
                 </.tabs_list>


### PR DESCRIPTION
## Summary by Sourcery

Fix the dashboard tab rendering issue by ensuring the tab trigger elements use the correct builder attribute in both DashboardOne and DashboardTwo modules.

Bug Fixes:
- Fix the dashboard tab rendering by updating the tab trigger elements to use the correct builder attribute.